### PR TITLE
Sample running actor

### DIFF
--- a/cmake/CompileBoost.cmake
+++ b/cmake/CompileBoost.cmake
@@ -10,7 +10,7 @@ function(compile_boost)
   set(BOOST_COMPILER_FLAGS -fvisibility=hidden -fPIC -std=c++14 -w)
   set(BOOST_CXX_COMPILER "${CMAKE_CXX_COMPILER}")
   if(APPLE)
-    set(BOOST_TOOLSET "darwin")
+    set(BOOST_TOOLSET "clang-darwin")
     # this is to fix a weird macOS issue -- by default
     # cmake would otherwise pass a compiler that can't
     # compile boost

--- a/fdbrpc/AsyncFileKAIO.actor.h
+++ b/fdbrpc/AsyncFileKAIO.actor.h
@@ -242,7 +242,11 @@ public:
 		// result = map(result, [=](int r) mutable { KAIOLogBlockEvent(io, OpLogEntry::READY, r); return r; });
 #endif
 
-		return success(result);
+		auto& actorLineageSet = IAsyncFileSystem::filesystem()->getActorLineageSet();
+		auto index = actorLineageSet.insert(currentLineage);
+		Future<Void> res = success(result);
+		actorLineageSet.erase(index);
+		return res;
 	}
 // TODO(alexmiller): Remove when we upgrade the dev docker image to >14.10
 #ifndef FALLOC_FL_ZERO_RANGE

--- a/fdbrpc/IAsyncFile.h
+++ b/fdbrpc/IAsyncFile.h
@@ -25,6 +25,7 @@
 
 #include <ctime>
 #include "flow/flow.h"
+#include "flow/WriteOnlySet.h"
 #include "fdbrpc/IRateControl.h"
 
 // All outstanding operations must be cancelled before the destructor of IAsyncFile is called.
@@ -117,6 +118,9 @@ public:
 
 	// Returns the time of the last modification of the file.
 	virtual Future<std::time_t> lastWriteTime(const std::string& filename) = 0;
+
+	// Returns the shared memory data structure used to store actor lineages.
+	virtual ActorLineageSet& getActorLineageSet() = 0;
 
 	static IAsyncFileSystem* filesystem() { return filesystem(g_network); }
 	static runCycleFuncPtr runCycleFunc() {

--- a/fdbrpc/Net2FileSystem.cpp
+++ b/fdbrpc/Net2FileSystem.cpp
@@ -89,6 +89,10 @@ Future<std::time_t> Net2FileSystem::lastWriteTime(const std::string& filename) {
 	return Net2AsyncFile::lastWriteTime(filename);
 }
 
+ActorLineageSet& Net2FileSystem::getActorLineageSet() {
+	return actorLineageSet;
+}
+
 void Net2FileSystem::newFileSystem(double ioTimeout, const std::string& fileSystemPath) {
 	g_network->setGlobal(INetwork::enFileSystem, (flowGlobalType) new Net2FileSystem(ioTimeout, fileSystemPath));
 }

--- a/fdbrpc/Net2FileSystem.h
+++ b/fdbrpc/Net2FileSystem.h
@@ -39,6 +39,8 @@ public:
 
 	Future<Void> renameFile(std::string const& from, std::string const& to) override;
 
+	ActorLineageSet& getActorLineageSet() override;
+
 	// void init();
 	static void stop();
 
@@ -52,6 +54,7 @@ public:
 	dev_t fileSystemDeviceId;
 	bool checkFileSystem;
 #endif
+	ActorLineageSet actorLineageSet;
 };
 
 #endif

--- a/fdbrpc/sim2.actor.cpp
+++ b/fdbrpc/sim2.actor.cpp
@@ -2494,6 +2494,10 @@ Future<std::time_t> Sim2FileSystem::lastWriteTime(const std::string& filename) {
 	return fileWrites[filename];
 }
 
+ActorLineageSet& Sim2FileSystem::getActorLineageSet() {
+	return actorLineageSet;
+}
+
 void Sim2FileSystem::newFileSystem() {
 	g_network->setGlobal(INetwork::enFileSystem, (flowGlobalType) new Sim2FileSystem());
 }

--- a/fdbrpc/simulator.h
+++ b/fdbrpc/simulator.h
@@ -471,6 +471,8 @@ public:
 
 	Future<std::time_t> lastWriteTime(const std::string& filename) override;
 
+	ActorLineageSet& getActorLineageSet() override;
+
 	Future<Void> renameFile(std::string const& from, std::string const& to) override;
 
 	Sim2FileSystem() {}
@@ -478,6 +480,8 @@ public:
 	~Sim2FileSystem() override {}
 
 	static void newFileSystem();
+
+	ActorLineageSet actorLineageSet;
 };
 
 #endif

--- a/fdbserver/fdbserver.actor.cpp
+++ b/fdbserver/fdbserver.actor.cpp
@@ -1948,6 +1948,7 @@ int main(int argc, char* argv[]) {
 				ASSERT(opts.connectionFile);
 
 				setupRunLoopProfiler();
+				setupSamplingProfiler();
 
 				auto dataFolder = opts.dataFolder;
 				if (!dataFolder.size())

--- a/flow/Platform.actor.cpp
+++ b/flow/Platform.actor.cpp
@@ -3681,6 +3681,14 @@ void* sampleThread(void* arg) {
 
 		// TODO: Copy actor lineage of currently running actor
 		// Read currentLineage
+		auto actorLineage = currentLineageThreadSafe.get();
+		printf("Currently running actor lineage (%p):\n", actorLineage.getPtr());
+		auto stack = actorLineage->stack(&StackLineage::actorName);
+		while (!stack.empty()) {
+			printf("%s ", stack.top());
+			stack.pop();
+		}
+		printf("\n");
 
 		auto diskAlps = IAsyncFileSystem::filesystem()->getActorLineageSet().copy();
 		printf("Disk ALPs: %d\n", diskAlps.size());

--- a/flow/Platform.actor.cpp
+++ b/flow/Platform.actor.cpp
@@ -3680,12 +3680,19 @@ void* sampleThread(void* arg) {
 		threadSleep(1.0); // TODO: Read sample rate from global config
 
 		// TODO: Copy actor lineage of currently running actor
+		// Read currentLineage
 
 		auto diskAlps = IAsyncFileSystem::filesystem()->getActorLineageSet().copy();
 		printf("Disk ALPs: %d\n", diskAlps.size());
 
 		// TODO: Call collect on all actor lineages
 		for (auto actorLineage : diskAlps) {
+			auto stack = actorLineage->stack(&StackLineage::actorName);
+			while (!stack.empty()) {
+				printf("%s ", stack.top());
+				stack.pop();
+			}
+			printf("\n");
 		}
 
 		// TODO: Serialize collected actor linage properties

--- a/flow/Platform.actor.cpp
+++ b/flow/Platform.actor.cpp
@@ -48,6 +48,8 @@
 #include "flow/UnitTest.h"
 #include "flow/FaultInjection.h"
 
+#include "fdbrpc/IAsyncFile.h"
+
 #ifdef _WIN32
 #include <windows.h>
 #include <winioctl.h>
@@ -3671,6 +3673,31 @@ void setupRunLoopProfiler() {
 #else
 	// No slow task profiling for other platforms!
 #endif
+}
+
+void* sampleThread(void* arg) {
+	while (true) {
+		threadSleep(1.0); // TODO: Read sample rate from global config
+
+		// TODO: Copy actor lineage of currently running actor
+
+		auto diskAlps = IAsyncFileSystem::filesystem()->getActorLineageSet().copy();
+		printf("Disk ALPs: %d\n", diskAlps.size());
+
+		// TODO: Call collect on all actor lineages
+		for (auto actorLineage : diskAlps) {
+		}
+
+		// TODO: Serialize collected actor linage properties
+	}
+
+	return nullptr;
+}
+
+void setupSamplingProfiler() {
+	// TODO: Add knob
+	TraceEvent("StartingSamplingProfilerThread");
+	startThread(&sampleThread, nullptr);
 }
 
 // UnitTest for getMemoryInfo

--- a/flow/Platform.h
+++ b/flow/Platform.h
@@ -741,6 +741,8 @@ void registerCrashHandler();
 void setupRunLoopProfiler();
 EXTERNC void setProfilingEnabled(int enabled);
 
+void setupSamplingProfiler();
+
 // Use _exit() or criticalError(), not exit()
 #define exit static_assert(false, "Calls to exit() are forbidden by policy");
 

--- a/flow/flow.cpp
+++ b/flow/flow.cpp
@@ -27,6 +27,7 @@
 #include <cinttypes>
 
 thread_local Reference<ActorLineage> currentLineage;
+WriteOnlyVariable<ActorLineage, unsigned> currentLineageThreadSafe;
 
 LineagePropertiesBase::~LineagePropertiesBase() {}
 


### PR DESCRIPTION
Sample debug output produced:

```
Time="1617642927.079750" Severity="10" LogGroup="default" Process="fdbserver.4000": Currently running actor lineage (0x7f80ef9959c0):
Time="1617642927.079814" Severity="10" LogGroup="default" Process="fdbserver.4000": fdbd workerServer ratekeeper actorCollection trackTLogQueueInfo
Time="1617642927.079823" Severity="10" LogGroup="default" Process="fdbserver.4000": Disk ALPs: 0
Time="1617642928.081289" Severity="10" LogGroup="default" Process="fdbserver.4000": Currently running actor lineage (0x7f80f5c88b00):
Time="1617642928.081386" Severity="10" LogGroup="default" Process="fdbserver.4000": pingLatencyLogger
Time="1617642928.081399" Severity="10" LogGroup="default" Process="fdbserver.4000": Disk ALPs: 0
Time="1617642929.082662" Severity="10" LogGroup="default" Process="fdbserver.4000": Currently running actor lineage (0x7f80ef9959c0):
Time="1617642929.082758" Severity="10" LogGroup="default" Process="fdbserver.4000": fdbd workerServer ratekeeper actorCollection trackTLogQueueInfo
Time="1617642929.082772" Severity="10" LogGroup="default" Process="fdbserver.4000": Disk ALPs: 0
Time="1617642930.083141" Severity="10" LogGroup="default" Process="fdbserver.4000": Currently running actor lineage (0x7f80f5c13940):
Time="1617642930.083201" Severity="10" LogGroup="default" Process="fdbserver.4000": fdbd workerServer actorCollection tLog databaseLogger
Time="1617642930.083210" Severity="10" LogGroup="default" Process="fdbserver.4000": Disk ALPs: 0
Time="1617642931.084619" Severity="10" LogGroup="default" Process="fdbserver.4000": Currently running actor lineage (0x7f80ef9729c0):
Time="1617642931.084713" Severity="10" LogGroup="default" Process="fdbserver.4000": fdbd workerServer commitProxyServer commitProxyServerCore actorCollection reportTxnTagCommitCost
Time="1617642931.084727" Severity="10" LogGroup="default" Process="fdbserver.4000": Disk ALPs: 0
Time="1617642932.086043" Severity="10" LogGroup="default" Process="fdbserver.4000": Currently running actor lineage (0x7f80ef9729c0):
Time="1617642932.086139" Severity="10" LogGroup="default" Process="fdbserver.4000": fdbd workerServer commitProxyServer commitProxyServerCore actorCollection reportTxnTagCommitCost
```

## General guideline:

- If this PR is ready to be merged (and all checkboxes below are either ticked or not applicable), make this a regular PR
- If this PR still needs work, please make this a draft PR
  - If you wish to get feedback/code-review, please add the label RFC to this PR

Please verify that all things listed below were considered and check them. If an item doesn't apply to this type of PR (for example a documentation change doesn't need to be performance tested), you should make a ~~strikethrough~~ (markdown syntax: `~~strikethrough~~`). More infos on the guidlines can be found [here](https://github.com/apple/foundationdb/wiki/FoundationDB-Commit-Process).

### Style
- [ ] All variable and function names make sense.
- [ ] The code is properly formatted (consider running `git clang-format`).

### Performance
- [ ] All CPU-hot paths are well optimized.
- [ ] The proper containers are used (for example `std::vector` vs `VectorRef`).
- [ ] There are no new known `SlowTask` traces.

### Testing
- [ ] The code was sufficiently tested in simulation.
- [ ] If there are new parameters or knobs, different values are tested in simulation.
- [ ] `ASSERT`, `ASSERT_WE_THINK`, and `TEST` macros are added in appropriate places.
- [ ] Unit tests were added for new algorithms and data structure that make sense to unit-test
- [ ] If this is a bugfix: there is a test that can easily reproduce the bug.
