### PR TITLE
Sample actors waiting on network

### DIFF
--- a/fdbclient/AnnotateActor.h
+++ b/fdbclient/AnnotateActor.h
@@ -1,5 +1,5 @@
 /*
- * InstrumentRequest.h
+ * AnnotateActor.h
  *
  * This source file is part of the FoundationDB open source project
  *
@@ -25,10 +25,10 @@
 
 // Used to manually instrument waiting actors to collect samples for the
 // sampling profiler.
-struct InstrumentRequest {
+struct AnnotateActor {
 	unsigned index;
 
-	InstrumentRequest() {}
+	AnnotateActor() {}
 
 	// This API isn't great. Ideally, no cleanup call is needed. I ran into an
 	// issue around the destructor being called twice because an instance of

--- a/fdbclient/InstrumentRequest.h
+++ b/fdbclient/InstrumentRequest.h
@@ -1,0 +1,50 @@
+/*
+ * InstrumentRequest.h
+ *
+ * This source file is part of the FoundationDB open source project
+ *
+ * Copyright 2013-2021 Apple Inc. and the FoundationDB project authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#pragma once
+
+#include "flow/flow.h"
+#include "flow/network.h"
+
+// Used to manually instrument waiting actors to collect samples for the
+// sampling profiler.
+struct InstrumentRequest {
+	unsigned index;
+
+	InstrumentRequest() {}
+
+	// This API isn't great. Ideally, no cleanup call is needed. I ran into an
+	// issue around the destructor being called twice because an instance of
+	// this class has to be stored as a class member (otherwise it goes away
+	// when wait is called), and due to how Flow does code generation the
+	// member will be default initialized and then initialized again when it is
+	// initially set. Then, the destructor will be called twice, causing issues
+	// when the WriteOnlySet tries to erase the same index twice. I'm working
+	// on this :)
+
+	void start() {
+		index = g_network->getActorLineageSet().insert(currentLineage);
+	}
+	
+	void complete() {
+		g_network->getActorLineageSet().erase(index);
+	}
+};
+

--- a/fdbclient/NativeAPI.actor.cpp
+++ b/fdbclient/NativeAPI.actor.cpp
@@ -32,11 +32,11 @@
 #include "fdbrpc/FailureMonitor.h"
 #include "fdbrpc/MultiInterface.h"
 
+#include "fdbclient/AnnotateActor.h"
 #include "fdbclient/Atomic.h"
 #include "fdbclient/ClusterInterface.h"
 #include "fdbclient/CoordinationInterface.h"
 #include "fdbclient/DatabaseContext.h"
-#include "fdbclient/InstrumentRequest.h"
 #include "fdbclient/JsonBuilder.h"
 #include "fdbclient/KeyRangeMap.h"
 #include "fdbclient/Knobs.h"
@@ -3027,8 +3027,8 @@ ACTOR Future<Standalone<RangeResultRef>> getRange(Database cx,
 						throw deterministicRandom()->randomChoice(
 						    std::vector<Error>{ transaction_too_old(), future_version() });
 					}
-					state InstrumentRequest request;
-					request.start();
+					state AnnotateActor annotation;
+					annotation.start();
 					GetKeyValuesReply _rep =
 					    wait(loadBalance(cx.getPtr(),
 					                     beginServer.second,
@@ -3039,7 +3039,7 @@ ACTOR Future<Standalone<RangeResultRef>> getRange(Database cx,
 					                     cx->enableLocalityLoadBalance ? &cx->queueModel : nullptr));
 					rep = _rep;
 					++cx->transactionPhysicalReadsCompleted;
-					request.complete();
+					annotation.complete();
 				} catch (Error&) {
 					++cx->transactionPhysicalReadsCompleted;
 					throw;

--- a/fdbclient/NativeAPI.actor.cpp
+++ b/fdbclient/NativeAPI.actor.cpp
@@ -3027,8 +3027,7 @@ ACTOR Future<Standalone<RangeResultRef>> getRange(Database cx,
 						throw deterministicRandom()->randomChoice(
 						    std::vector<Error>{ transaction_too_old(), future_version() });
 					}
-					state AnnotateActor annotation;
-					annotation.start();
+					state AnnotateActor annotation(currentLineage);
 					GetKeyValuesReply _rep =
 					    wait(loadBalance(cx.getPtr(),
 					                     beginServer.second,
@@ -3039,7 +3038,6 @@ ACTOR Future<Standalone<RangeResultRef>> getRange(Database cx,
 					                     cx->enableLocalityLoadBalance ? &cx->queueModel : nullptr));
 					rep = _rep;
 					++cx->transactionPhysicalReadsCompleted;
-					annotation.complete();
 				} catch (Error&) {
 					++cx->transactionPhysicalReadsCompleted;
 					throw;

--- a/fdbrpc/FlowTests.actor.cpp
+++ b/fdbrpc/FlowTests.actor.cpp
@@ -24,6 +24,7 @@
 #include "flow/UnitTest.h"
 #include "flow/DeterministicRandom.h"
 #include "flow/IThreadPool.h"
+#include "flow/WriteOnlySet.h"
 #include "fdbrpc/fdbrpc.h"
 #include "fdbrpc/IAsyncFile.h"
 #include "flow/TLSConfig.actor.h"
@@ -282,6 +283,9 @@ struct YieldMockNetwork final : INetwork, ReferenceCounted<YieldMockNetwork> {
 	const TLSConfig& getTLSConfig() const override {
 		static TLSConfig emptyConfig;
 		return emptyConfig;
+	}
+	ActorLineageSet& getActorLineageSet() override {
+		throw std::exception();
 	}
 	ProtocolVersion protocolVersion() override { return baseNetwork->protocolVersion(); }
 };

--- a/fdbrpc/sim2.actor.cpp
+++ b/fdbrpc/sim2.actor.cpp
@@ -31,6 +31,7 @@
 #include "flow/IThreadPool.h"
 #include "flow/ProtocolVersion.h"
 #include "flow/Util.h"
+#include "flow/WriteOnlySet.h"
 #include "fdbrpc/IAsyncFile.h"
 #include "fdbrpc/AsyncFileCached.actor.h"
 #include "fdbrpc/AsyncFileNonDurable.actor.h"
@@ -974,6 +975,10 @@ public:
 	}
 
 	bool checkRunnable() override { return net2->checkRunnable(); }
+
+	ActorLineageSet& getActorLineageSet() override {
+		return actorLineageSet;
+	}
 
 	void stop() override { isStopped = true; }
 	void addStopCallback(std::function<void()> fn) override { stopCallbacks.emplace_back(std::move(fn)); }
@@ -2117,6 +2122,8 @@ public:
 	// Whether or not yield has returned true during the current iteration of the run loop
 	bool yielded;
 	int yield_limit; // how many more times yield may return false before next returning true
+
+	ActorLineageSet actorLineageSet;
 };
 
 class UDPSimSocket : public IUDPSocket, ReferenceCounted<UDPSimSocket> {

--- a/flow/Net2.actor.cpp
+++ b/flow/Net2.actor.cpp
@@ -198,6 +198,8 @@ public:
 
 	bool checkRunnable() override;
 
+	ActorLineageSet& getActorLineageSet() override;
+
 	bool useThreadPool;
 
 	// private:
@@ -224,6 +226,8 @@ public:
 	// May be accessed off the network thread, e.g. by onMainThread
 	std::atomic<bool> stopped;
 	mutable std::map<IPAddress, bool> addressOnHostCache;
+
+	ActorLineageSet actorLineageSet;
 
 	std::atomic<bool> started;
 
@@ -1375,6 +1379,10 @@ void Net2::initMetrics() {
 
 bool Net2::checkRunnable() {
 	return !started.exchange(true);
+}
+
+ActorLineageSet& Net2::getActorLineageSet() {
+	return actorLineageSet;
 }
 
 void Net2::run() {

--- a/flow/Platform.actor.cpp
+++ b/flow/Platform.actor.cpp
@@ -3679,8 +3679,7 @@ void* sampleThread(void* arg) {
 	while (true) {
 		threadSleep(1.0); // TODO: Read sample rate from global config
 
-		// TODO: Copy actor lineage of currently running actor
-		// Read currentLineage
+		// Get actor lineage of currently running actor.
 		auto actorLineage = currentLineageThreadSafe.get();
 		printf("Currently running actor lineage (%p):\n", actorLineage.getPtr());
 		auto stack = actorLineage->stack(&StackLineage::actorName);
@@ -3690,11 +3689,16 @@ void* sampleThread(void* arg) {
 		}
 		printf("\n");
 
+		// Get lineage of actors waiting on disk.
 		auto diskAlps = IAsyncFileSystem::filesystem()->getActorLineageSet().copy();
-		printf("Disk ALPs: %d\n", diskAlps.size());
+		// printf("Disk ALPs: %d\n", diskAlps.size());
+
+		// TODO: Get lineage of actors waiting on network
+		auto networkAlps = g_network->getActorLineageSet().copy();
+		printf("Network ALPs: %d\n", networkAlps.size());
 
 		// TODO: Call collect on all actor lineages
-		for (auto actorLineage : diskAlps) {
+		for (auto actorLineage : networkAlps) {
 			auto stack = actorLineage->stack(&StackLineage::actorName);
 			while (!stack.empty()) {
 				printf("%s ", stack.top());

--- a/flow/network.h
+++ b/flow/network.h
@@ -34,6 +34,7 @@
 #include "flow/Arena.h"
 #include "flow/IRandom.h"
 #include "flow/Trace.h"
+#include "flow/WriteOnlySet.h"
 
 enum class TaskPriority {
 	Max = 1000000,
@@ -534,6 +535,9 @@ public:
 	// If the network has not been run and this function has not been previously called, returns true. Otherwise,
 	// returns false.
 	virtual bool checkRunnable() = 0;
+
+	// Returns the shared memory data structure used to store actor lineages.
+	virtual ActorLineageSet& getActorLineageSet() = 0;
 
 	virtual ProtocolVersion protocolVersion() = 0;
 


### PR DESCRIPTION
Sample output from a client running a `getRange`:

```
Currently running actor lineage (0x7fad70002b70):
doOnMainThreadVoid monitorProxies monitorProxiesOneGeneration connectionKeeper connectionMonitor
Network ALPs: 1
doOnMainThread readWithConflictRangeRYW getRangeValue readVersionBatcher getRange
```

## General guideline:

- If this PR is ready to be merged (and all checkboxes below are either ticked or not applicable), make this a regular PR
- If this PR still needs work, please make this a draft PR
  - If you wish to get feedback/code-review, please add the label RFC to this PR

Please verify that all things listed below were considered and check them. If an item doesn't apply to this type of PR (for example a documentation change doesn't need to be performance tested), you should make a ~~strikethrough~~ (markdown syntax: `~~strikethrough~~`). More infos on the guidlines can be found [here](https://github.com/apple/foundationdb/wiki/FoundationDB-Commit-Process).

### Style
- [ ] All variable and function names make sense.
- [ ] The code is properly formatted (consider running `git clang-format`).

### Performance
- [ ] All CPU-hot paths are well optimized.
- [ ] The proper containers are used (for example `std::vector` vs `VectorRef`).
- [ ] There are no new known `SlowTask` traces.

### Testing
- [ ] The code was sufficiently tested in simulation.
- [ ] If there are new parameters or knobs, different values are tested in simulation.
- [ ] `ASSERT`, `ASSERT_WE_THINK`, and `TEST` macros are added in appropriate places.
- [ ] Unit tests were added for new algorithms and data structure that make sense to unit-test
- [ ] If this is a bugfix: there is a test that can easily reproduce the bug.
