### PR TITLE
Fix msgpack install

### DIFF
--- a/cmake/GetMsgpack.cmake
+++ b/cmake/GetMsgpack.cmake
@@ -9,7 +9,10 @@ else()
   ExternalProject_add(msgpackProject
     URL "https://github.com/msgpack/msgpack-c/releases/download/cpp-3.3.0/msgpack-3.3.0.tar.gz"
     URL_HASH SHA256=6e114d12a5ddb8cb11f669f83f32246e484a8addd0ce93f274996f1941c1f07b
-    CONFIGURE_COMMAND BUILD_COMMAND INSTALL_COMMAND)
+    CONFIGURE_COMMAND ""
+    BUILD_COMMAND ""
+    INSTALL_COMMAND ""
+  )
 
   ExternalProject_Get_property(msgpackProject SOURCE_DIR)
   target_include_directories(msgpack SYSTEM INTERFACE "${SOURCE_DIR}/include")


### PR DESCRIPTION
I was having trouble building, getting the error

```
[10/594] Performing install step for 'msgpackProject'                                                                                                                                                     FAILED: msgpackProject-prefix/src/msgpackProject-stamp/msgpackProject-install                                                                                                                             cd /home/ljoswiak/build/msgpackProject-prefix/src/msgpackProject-build && /usr/local/bin/cmake --build . --target install && /usr/local/bin/cmake -E touch /home/ljoswiak/build/msgpackProject-prefix/src/
msgpackProject-stamp/msgpackProject-install                                                                                                                                                               [0/1] Install the project...                                                                                                                                                                              -- Install configuration: ""                                                                                                                                                                              -- Installing: /usr/local/lib/libmsgpackc.so.2.0.0
CMake Error at cmake_install.cmake:52 (file):                                                                                                                                                               file INSTALL cannot copy file                                                                                                                                                                             "/home/ljoswiak/build/msgpackProject-prefix/src/msgpackProject-build/libmsgpackc.so.2.0.0"                                                                                                                to "/usr/local/lib/libmsgpackc.so.2.0.0".
                                                                                                                                                                                                          
FAILED: CMakeFiles/install.util
cd /home/ljoswiak/build/msgpackProject-prefix/src/msgpackProject-build && /usr/local/bin/cmake -P cmake_install.cmake
ninja: build stopped: subcommand failed.
```

This change seems to fix it.

## General guideline:

- If this PR is ready to be merged (and all checkboxes below are either ticked or not applicable), make this a regular PR
- If this PR still needs work, please make this a draft PR
  - If you wish to get feedback/code-review, please add the label RFC to this PR

Please verify that all things listed below were considered and check them. If an item doesn't apply to this type of PR (for example a documentation change doesn't need to be performance tested), you should make a ~~strikethrough~~ (markdown syntax: `~~strikethrough~~`). More infos on the guidlines can be found [here](https://github.com/apple/foundationdb/wiki/FoundationDB-Commit-Process).

### Style
- [ ] All variable and function names make sense.
- [ ] The code is properly formatted (consider running `git clang-format`).

### Performance
- [ ] All CPU-hot paths are well optimized.
- [ ] The proper containers are used (for example `std::vector` vs `VectorRef`).
- [ ] There are no new known `SlowTask` traces.

### Testing
- [ ] The code was sufficiently tested in simulation.
- [ ] If there are new parameters or knobs, different values are tested in simulation.
- [ ] `ASSERT`, `ASSERT_WE_THINK`, and `TEST` macros are added in appropriate places.
- [ ] Unit tests were added for new algorithms and data structure that make sense to unit-test
- [ ] If this is a bugfix: there is a test that can easily reproduce the bug.
