### PR TITLE
Add well known endpoint to all workers

### DIFF
--- a/cmake/GetMsgpack.cmake
+++ b/cmake/GetMsgpack.cmake
@@ -9,7 +9,10 @@ else()
   ExternalProject_add(msgpackProject
     URL "https://github.com/msgpack/msgpack-c/releases/download/cpp-3.3.0/msgpack-3.3.0.tar.gz"
     URL_HASH SHA256=6e114d12a5ddb8cb11f669f83f32246e484a8addd0ce93f274996f1941c1f07b
-    CONFIGURE_COMMAND BUILD_COMMAND INSTALL_COMMAND)
+    CONFIGURE_COMMAND ""
+    BUILD_COMMAND ""
+    INSTALL_COMMAND ""
+  )
 
   ExternalProject_Get_property(msgpackProject SOURCE_DIR)
   target_include_directories(msgpack SYSTEM INTERFACE "${SOURCE_DIR}/include")

--- a/fdbclient/NativeAPI.actor.cpp
+++ b/fdbclient/NativeAPI.actor.cpp
@@ -1046,6 +1046,10 @@ DatabaseContext::DatabaseContext(Reference<AsyncVar<Reference<ClusterConnectionF
 		    std::make_unique<ClientProfilingImpl>(
 		        KeyRangeRef(LiteralStringRef("profiling/"), LiteralStringRef("profiling0"))
 		            .withPrefix(SpecialKeySpace::getModuleRange(SpecialKeySpace::MODULE::MANAGEMENT).begin)));
+		registerSpecialKeySpaceModule(
+		    SpecialKeySpace::MODULE::ACTORLINEAGE,
+		    SpecialKeySpace::IMPLTYPE::READONLY,
+		    std::make_unique<ActorLineageImpl>(SpecialKeySpace::getModuleRange(SpecialKeySpace::MODULE::ACTORLINEAGE)));
 	}
 	if (apiVersionAtLeast(630)) {
 		registerSpecialKeySpaceModule(SpecialKeySpace::MODULE::TRANSACTION,

--- a/fdbclient/ProcessInterface.h
+++ b/fdbclient/ProcessInterface.h
@@ -1,0 +1,57 @@
+/*
+ * ProcessInterface.h
+ *
+ * This source file is part of the FoundationDB open source project
+ *
+ * Copyright 2013-2021 Apple Inc. and the FoundationDB project authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#include "fdbclient/FDBTypes.h"
+#include "fdbrpc/fdbrpc.h"
+
+constexpr UID WLTOKEN_PROCESS(-1, 11);
+
+struct ProcessInterface {
+	constexpr static FileIdentifier file_identifier = 985636;
+	RequestStream<struct GetProcessInterfaceRequest> getInterface;
+	RequestStream<struct EchoRequest> echo;
+
+	template <class Ar>
+	void serialize(Ar& ar) {
+		serializer(ar, echo);
+	}
+};
+
+struct GetProcessInterfaceRequest {
+	constexpr static FileIdentifier file_identifier = 7632546;
+	ReplyPromise<ProcessInterface> reply;
+
+	template <class Ar>
+	void serialize(Ar& ar) {
+		serializer(ar, reply);
+	}
+};
+
+// TODO: Used for demonstration purposes, remove in later PR
+struct EchoRequest {
+	constexpr static FileIdentifier file_identifier = 10624019;
+	std::string message;
+	ReplyPromise<std::string> reply;
+
+	template <class Ar>
+	void serialize(Ar& ar) {
+		serializer(ar, message, reply);
+	}
+};

--- a/fdbclient/SpecialKeySpace.actor.cpp
+++ b/fdbclient/SpecialKeySpace.actor.cpp
@@ -71,7 +71,6 @@ std::unordered_map<SpecialKeySpace::MODULE, KeyRange> SpecialKeySpace::moduleToB
 	  KeyRangeRef(LiteralStringRef("\xff\xff/actor_lineage/"), LiteralStringRef("\xff\xff/actor_lineage0")) }
 };
 
-// TODO: Similar for actor lineage?
 std::unordered_map<std::string, KeyRange> SpecialKeySpace::managementApiCommandToRange = {
 	{ "exclude",
 	  KeyRangeRef(LiteralStringRef("excluded/"), LiteralStringRef("excluded0"))

--- a/fdbclient/SpecialKeySpace.actor.cpp
+++ b/fdbclient/SpecialKeySpace.actor.cpp
@@ -22,6 +22,7 @@
 #include "boost/algorithm/string.hpp"
 
 #include "fdbclient/Knobs.h"
+#include "fdbclient/ProcessInterface.h"
 #include "fdbclient/SpecialKeySpace.actor.h"
 #include "flow/Arena.h"
 #include "flow/UnitTest.h"
@@ -65,9 +66,12 @@ std::unordered_map<SpecialKeySpace::MODULE, KeyRange> SpecialKeySpace::moduleToB
 	{ SpecialKeySpace::MODULE::CONFIGURATION,
 	  KeyRangeRef(LiteralStringRef("\xff\xff/configuration/"), LiteralStringRef("\xff\xff/configuration0")) },
 	{ SpecialKeySpace::MODULE::TRACING,
-	  KeyRangeRef(LiteralStringRef("\xff\xff/tracing/"), LiteralStringRef("\xff\xff/tracing0")) }
+	  KeyRangeRef(LiteralStringRef("\xff\xff/tracing/"), LiteralStringRef("\xff\xff/tracing0")) },
+	{ SpecialKeySpace::MODULE::ACTORLINEAGE,
+	  KeyRangeRef(LiteralStringRef("\xff\xff/actor_lineage/"), LiteralStringRef("\xff\xff/actor_lineage0")) }
 };
 
+// TODO: Similar for actor lineage?
 std::unordered_map<std::string, KeyRange> SpecialKeySpace::managementApiCommandToRange = {
 	{ "exclude",
 	  KeyRangeRef(LiteralStringRef("excluded/"), LiteralStringRef("excluded0"))
@@ -1793,4 +1797,35 @@ void ClientProfilingImpl::clear(ReadYourWritesTransaction* ryw, const KeyRef& ke
 	    ryw,
 	    "profile",
 	    "Clear operation is forbidden for profile client. You can set it to default to disable profiling.");
+}
+
+ActorLineageImpl::ActorLineageImpl(KeyRangeRef kr) : SpecialKeyRangeReadImpl(kr) {}
+
+ACTOR static Future<Standalone<RangeResultRef>> actorLineageGetRangeActor(ReadYourWritesTransaction* ryw,
+                                                                          KeyRef prefix,
+                                                                          KeyRangeRef kr) {
+	state Standalone<RangeResultRef> result;
+	Standalone<StringRef> addressString = kr.begin.removePrefix(prefix);
+
+	try {
+		auto address = NetworkAddress::parse(addressString.contents().toString());
+
+		state ProcessInterface process;
+		process.getInterface = RequestStream<GetProcessInterfaceRequest>(Endpoint({ address }, WLTOKEN_PROCESS));
+		ProcessInterface p = wait(retryBrokenPromise(process.getInterface, GetProcessInterfaceRequest{}));
+		process = p;
+
+		EchoRequest echoRequest;
+		echoRequest.message = "Hello";
+		std::string response = wait(process.echo.getReply(echoRequest));
+		result.push_back_deep(result.arena(), KeyValueRef(kr.begin, response));
+	} catch (Error& e) {
+		TraceEvent(SevDebug, "SpecialKeysNetworkParseError").error(e);
+	}
+
+	return result;
+}
+
+Future<Standalone<RangeResultRef>> ActorLineageImpl::getRange(ReadYourWritesTransaction* ryw, KeyRangeRef kr) const {
+	return actorLineageGetRangeActor(ryw, getKeyRange().begin, kr);
 }

--- a/fdbclient/SpecialKeySpace.actor.h
+++ b/fdbclient/SpecialKeySpace.actor.h
@@ -142,6 +142,7 @@ public:
 class SpecialKeySpace {
 public:
 	enum class MODULE {
+		ACTORLINEAGE, // Sampling data
 		CLUSTERFILEPATH,
 		CONFIGURATION, // Configuration of the cluster
 		CONNECTIONSTRING,
@@ -375,6 +376,12 @@ public:
 	Future<Optional<std::string>> commit(ReadYourWritesTransaction* ryw) override;
 	void clear(ReadYourWritesTransaction* ryw, const KeyRangeRef& range) override;
 	void clear(ReadYourWritesTransaction* ryw, const KeyRef& key) override;
+};
+
+class ActorLineageImpl : public SpecialKeyRangeReadImpl {
+public:
+	explicit ActorLineageImpl(KeyRangeRef kr);
+	Future<Standalone<RangeResultRef>> getRange(ReadYourWritesTransaction* ryw, KeyRangeRef kr) const override;
 };
 
 #include "flow/unactorcompiler.h"

--- a/fdbrpc/FlowTransport.actor.cpp
+++ b/fdbrpc/FlowTransport.actor.cpp
@@ -334,7 +334,7 @@ ACTOR Future<Void> pingLatencyLogger(TransportData* self) {
 }
 
 TransportData::TransportData(uint64_t transportId)
-  : endpoints(/*wellKnownTokenCount*/ 11), endpointNotFoundReceiver(endpoints), pingReceiver(endpoints),
+  : endpoints(/*wellKnownTokenCount*/ 12), endpointNotFoundReceiver(endpoints), pingReceiver(endpoints),
     warnAlwaysForLargePacket(true), lastIncompatibleMessage(0), transportId(transportId),
     numIncompatibleConnections(0) {
 	degraded = makeReference<AsyncVar<bool>>(false);

--- a/flow/Platform.actor.cpp
+++ b/flow/Platform.actor.cpp
@@ -3683,28 +3683,12 @@ void* sampleThread(void* arg) {
 
 		// Get actor lineage of currently running actor.
 		auto actorLineage = currentLineageThreadSafe.get();
-		printf("Currently running actor lineage (%p):\n", actorLineage.getPtr());
-		auto stack = actorLineage->stack(&StackLineage::actorName);
-		while (!stack.empty()) {
-			printf("%s ", stack.back());
-			stack.pop_back();
-		}
-		printf("\n");
+		// TODO: Use actorLineage
 
 		for (const auto& [waitState, lineageFn] : samples) {
 			auto alps = lineageFn();
 
 			// TODO: Serialize collected actor linage properties
-
-			printf("Wait State #%d ALPs (%d):\n", waitState, alps.size());
-			for (auto actorLineage : alps) {
-				auto stack = actorLineage->stack(&StackLineage::actorName);
-				while (!stack.empty()) {
-					printf("%s ", stack.back());
-					stack.pop_back();
-				}
-				printf("\n");
-			}
 		}
 	}
 


### PR DESCRIPTION
Also adds beginnings of special key space functionality to request data from worker processes. Currently, you can run `get \xff\xff/actor_lineage/127.0.0.1:4000` and the address will be parsed and a message sent to the process at the given IP and port.

## General guideline:

- If this PR is ready to be merged (and all checkboxes below are either ticked or not applicable), make this a regular PR
- If this PR still needs work, please make this a draft PR
  - If you wish to get feedback/code-review, please add the label RFC to this PR

Please verify that all things listed below were considered and check them. If an item doesn't apply to this type of PR (for example a documentation change doesn't need to be performance tested), you should make a ~~strikethrough~~ (markdown syntax: `~~strikethrough~~`). More infos on the guidlines can be found [here](https://github.com/apple/foundationdb/wiki/FoundationDB-Commit-Process).

### Style
- [ ] All variable and function names make sense.
- [ ] The code is properly formatted (consider running `git clang-format`).

### Performance
- [ ] All CPU-hot paths are well optimized.
- [ ] The proper containers are used (for example `std::vector` vs `VectorRef`).
- [ ] There are no new known `SlowTask` traces.

### Testing
- [ ] The code was sufficiently tested in simulation.
- [ ] If there are new parameters or knobs, different values are tested in simulation.
- [ ] `ASSERT`, `ASSERT_WE_THINK`, and `TEST` macros are added in appropriate places.
- [ ] Unit tests were added for new algorithms and data structure that make sense to unit-test
- [ ] If this is a bugfix: there is a test that can easily reproduce the bug.
