### PR TITLE
Fixes/fix simulation

### DIFF
--- a/fdbclient/AnnotateActor.h
+++ b/fdbclient/AnnotateActor.h
@@ -35,6 +35,9 @@ struct AnnotateActor {
 
 	AnnotateActor(Reference<ActorLineage> lineage) : set(true) {
 		index = g_network->getActorLineageSet().insert(lineage);
+		if (index == ActorLineageSet::npos) {
+			set = false;
+		}
 	}
 
 	AnnotateActor(const AnnotateActor& other) = delete;

--- a/fdbclient/GlobalConfig.actor.cpp
+++ b/fdbclient/GlobalConfig.actor.cpp
@@ -48,10 +48,6 @@ void GlobalConfig::create(DatabaseContext* cx, Reference<AsyncVar<ClientDBInfo>>
 	}
 }
 
-void GlobalConfig::updateDBInfo(Reference<AsyncVar<ClientDBInfo>> dbInfo) {
-	_updater = updater(&GlobalConfig::globalConfig(), dbInfo);
-}
-
 GlobalConfig& GlobalConfig::globalConfig() {
 	void* res = g_network->global(INetwork::enGlobalConfig);
 	ASSERT(res);
@@ -201,6 +197,7 @@ ACTOR Future<Void> GlobalConfig::refresh(GlobalConfig* self) {
 // Applies updates to the local copy of the global configuration when this
 // process receives an updated history.
 ACTOR Future<Void> GlobalConfig::updater(GlobalConfig* self, Reference<AsyncVar<ClientDBInfo>> dbInfo) {
+	// wait(self->cx->onConnected());
 	wait(self->migrate(self));
 
 	wait(self->refresh(self));

--- a/fdbclient/GlobalConfig.actor.cpp
+++ b/fdbclient/GlobalConfig.actor.cpp
@@ -56,7 +56,7 @@ GlobalConfig& GlobalConfig::globalConfig() {
 }
 
 void GlobalConfig::updateDBInfo(Reference<AsyncVar<ClientDBInfo>> dbInfo) {
-	this->dbInfo = dbInfo;
+	// this->dbInfo = dbInfo;
 }
 
 Key GlobalConfig::prefixedKey(KeyRef key) {

--- a/fdbclient/GlobalConfig.actor.h
+++ b/fdbclient/GlobalConfig.actor.h
@@ -83,14 +83,6 @@ public:
 	// For example, given "config/a", returns "\xff\xff/global_config/config/a".
 	static Key prefixedKey(KeyRef key);
 
-	// Update the ClientDBInfo object used internally to check for updates to
-	// global configuration. The ClientDBInfo reference must be the same one
-	// used in the cluster controller, but fdbserver requires initial creation
-	// of the GlobalConfig class before the cluster controller is initialized.
-	// This function allows the ClientDBInfo object to be updated after create
-	// was called.
-	void updateDBInfo(Reference<AsyncVar<ClientDBInfo>> dbInfo);
-
 	// Get a value from the framework. Values are returned as a ConfigValue
 	// reference which also contains the arena holding the object. As long as
 	// the caller keeps the ConfigValue reference, the value is guaranteed to

--- a/fdbclient/GlobalConfig.actor.h
+++ b/fdbclient/GlobalConfig.actor.h
@@ -77,6 +77,13 @@ public:
 	// configuration.
 	static GlobalConfig& globalConfig();
 
+	// Updates the ClientDBInfo object used by global configuration to read new
+	// data. For server processes, this value needs to be set by the cluster
+	// controller, but global config is initialized before the cluster
+	// controller is, so this function provides a mechanism to update the
+	// object after initialization.
+	void updateDBInfo(Reference<AsyncVar<ClientDBInfo>> dbInfo);
+
 	// Use this function to turn a global configuration key defined above into
 	// the full path needed to set the value in the database.
 	//
@@ -149,9 +156,10 @@ private:
 
 	ACTOR static Future<Void> migrate(GlobalConfig* self);
 	ACTOR static Future<Void> refresh(GlobalConfig* self);
-	ACTOR static Future<Void> updater(GlobalConfig* self, Reference<AsyncVar<ClientDBInfo>> dbInfo);
+	ACTOR static Future<Void> updater(GlobalConfig* self);
 
 	Database cx;
+	Reference<AsyncVar<ClientDBInfo>> dbInfo;
 	Future<Void> _updater;
 	Promise<Void> initialized;
 	AsyncTrigger configChanged;

--- a/fdbrpc/AsyncFileKAIO.actor.h
+++ b/fdbrpc/AsyncFileKAIO.actor.h
@@ -244,6 +244,7 @@ public:
 
 		auto& actorLineageSet = IAsyncFileSystem::filesystem()->getActorLineageSet();
 		auto index = actorLineageSet.insert(currentLineage);
+		ASSERT(index != ActorLineageSet::npos);
 		Future<Void> res = success(result);
 		actorLineageSet.erase(index);
 		return res;

--- a/fdbserver/ClusterController.actor.cpp
+++ b/fdbserver/ClusterController.actor.cpp
@@ -135,7 +135,9 @@ public:
 		                                                                         true,
 		                                                                         TaskPriority::DefaultEndpoint,
 		                                                                         true)) // SOMEDAY: Locality!
-		{}
+		{
+			GlobalConfig::globalConfig().updateDBInfo(clientInfo);
+		}
 
 		void setDistributor(const DataDistributorInterface& interf) {
 			auto newInfo = serverInfo->get();

--- a/fdbserver/ClusterController.actor.cpp
+++ b/fdbserver/ClusterController.actor.cpp
@@ -135,9 +135,7 @@ public:
 		                                                                         true,
 		                                                                         TaskPriority::DefaultEndpoint,
 		                                                                         true)) // SOMEDAY: Locality!
-		{
-			GlobalConfig::globalConfig().updateDBInfo(clientInfo);
-		}
+		{}
 
 		void setDistributor(const DataDistributorInterface& interf) {
 			auto newInfo = serverInfo->get();

--- a/flow/WriteOnlySet.actor.cpp
+++ b/flow/WriteOnlySet.actor.cpp
@@ -62,6 +62,7 @@ bool WriteOnlySet<T, IndexType, CAPACITY>::eraseImpl(Index idx) {
 
 template <class T, class IndexType, IndexType CAPACITY>
 bool WriteOnlySet<T, IndexType, CAPACITY>::erase(Index idx) {
+	ASSERT(idx >= 0 && idx < CAPACITY);
 	auto res = eraseImpl(idx);
 	ASSERT(freeQueue.push(idx));
 	return res;
@@ -86,7 +87,6 @@ bool WriteOnlySet<T, IndexType, CAPACITY>::replace(Index idx, const Reference<T>
 				if (ptr) {
 					reinterpret_cast<T*>(ptr)->delref();
 				}
-				_set[idx].store(lineagePtr);
 				return ptr != 0;
 			}
 		}
@@ -98,7 +98,7 @@ WriteOnlySet<T, IndexType, CAPACITY>::WriteOnlySet() : _set(CAPACITY) {
 	// insert the free indexes in reverse order
 	for (unsigned i = CAPACITY; i > 0; --i) {
 		freeQueue.push(i - 1);
-		_set[i] = uintptr_t(0);
+		std::atomic_init(&_set[i - 1], uintptr_t(0));
 	}
 }
 

--- a/flow/flow.cpp
+++ b/flow/flow.cpp
@@ -31,7 +31,7 @@ WriteOnlyVariable<ActorLineage, unsigned> currentLineageThreadSafe;
 
 LineagePropertiesBase::~LineagePropertiesBase() {}
 
-ActorLineage::ActorLineage() : parent(currentLineage) {}
+ActorLineage::ActorLineage() : properties(), parent(currentLineage) {}
 
 ActorLineage::~ActorLineage() {
 	for (auto ptr : properties) {


### PR DESCRIPTION
Fixes:

 1. Use the right index when initializing the WriteOnlySet's vector of atomics. Also switch to std::atomic_init to initialize each atomic in the vector (cannot default construct the atomics in the vector because std::atomic does not have a copy constructor).
2. Add failure check for when items cannot be inserted into the WriteOnlySet due to capacity constraints. This situation occurs when `copy` is not called on the WriteOnlySet, such as when sampling is disabled. The `copy` function is what clears the WriteOnlySet.
3. ~~GlobalConfig fix to let fdbserver processes correctly receive notifications about changed global config values.~~ <- this is still broken, see below
4. Add various ASSERTs to verify data in WriteOnlySet.
5. ~~Removes a special key space unit test that tests the CLI `profile client` functionality. This functionality still works, but there are issues when testing it because the data is now stored in global configuration.~~
6. ~~Remove ClientProfilingImpl in special key space which is now not used.~~

Edit: 5 and 6 are no longer part of this PR, as they were not actually causing issues (I don't think).

I am still seeing two main issues:
* The `SpecialKeySpaceCorrectness` workload fails with unseed mismatch errors in Joshua (`20210502-053418-ljoswiak-30070846521b35ed` is a 5k run of just `SpecialKeySpaceCorrectness.toml`). However, I get the same issue when running on master... so I'm not sure why this isn't showing up on the nightlies.
* ~~There are failures in the restarting test from 5.2.0 (see `20210502-062723-ljoswiak-dee420f4864a394c`). These point back to GlobalConfig.actor.cpp:194, I think it is attempting to run a transaction before the database is correctly set up or something.. these are hard to reproduce because I don't have the TLS plugin built.~~ (removing the `updateDBInfo` function fixed this, although it broke global config somewhat, requiring a restart instead of hot reloading).