### PR TITLE
Add a reseed method to DeterministicRandom

### DIFF
--- a/flow/DeterministicRandom.cpp
+++ b/flow/DeterministicRandom.cpp
@@ -36,6 +36,11 @@ DeterministicRandom::DeterministicRandom(uint32_t seed, bool useRandLog)
 	UNSTOPPABLE_ASSERT(seed != 0); // docs for mersenne twister say x0>0
 };
 
+void DeterministicRandom::reseed(uint32_t seed) {
+	random = std::mt19937((unsigned long)seed);
+	next = (uint64_t(random()) << 32) ^ random();
+}
+
 double DeterministicRandom::random01() {
 	double d = gen64() / double(uint64_t(-1));
 	if (randLog && useRandLog)

--- a/flow/DeterministicRandom.h
+++ b/flow/DeterministicRandom.h
@@ -40,6 +40,7 @@ private:
 
 public:
 	DeterministicRandom(uint32_t seed, bool useRandLog = false);
+	void reseed(uint32_t seed);
 	double random01() override;
 	int randomInt(int min, int maxPlusOne) override;
 	int64_t randomInt64(int64_t min, int64_t maxPlusOne) override;


### PR DESCRIPTION
Make it possible to reseed a `DeterministicRandom` RNG.

# Code-Reviewer Section

The general guidelines can be found [here](https://github.com/apple/foundationdb/wiki/FoundationDB-Commit-Process).

Please check each of the following things and check *all* boxes before accepting a PR.

- [x] The PR has a description, explaining both the problem and the solution.
- [x] The description mentions which forms of testing were done and the testing seems reasonable.
- [x] Every function/class/actor that was touched is reasonably well documented.

## For Release-Branches

If this PR is made against a release-branch, please also check the following:

- [ ] This change/bugfix is a cherry-pick from the next younger branch (younger `release-branch` or `master` if this is the youngest branch)
- [ ] There is a good reason why this PR needs to go into a release branch and this reason is documented (either in the description above or in a linked GitHub issue)
