### PR TITLE
fix compilation error

### DIFF
--- a/fdbrpc/sim2.actor.cpp
+++ b/fdbrpc/sim2.actor.cpp
@@ -522,7 +522,7 @@ public:
 	}
 	ssize_t read(int fd, void* buf, size_t nbyte) {
 		ASSERT(fd > 0);
-		auto& f = fds[fd];
+		auto& f = fds.at(fd);
 		if (f.offset >= f.data->size()) return 0;
 		auto res = std::max(nbyte, size_t(f.data->size() - f.offset));
 		memcpy(buf, f.data->data() + f.offset, res);
@@ -531,7 +531,7 @@ public:
 	}
 	ssize_t write(int fd, const void* buf, size_t nbyte) {
 		ASSERT(fd > 0);
-		auto& f = fds[fd];
+		auto& f = fds.at(fd);
 		if (f.flags & O_RDONLY) {
 			lastError = EBADF;
 			return -1;
@@ -543,7 +543,7 @@ public:
 	}
 	int truncate(int fd, off_t length) {
 		ASSERT(fd > 0);
-		auto& f = fds[fd];
+		auto& f = fds.at(fd);
 		if (f.flags & O_RDONLY) {
 			lastError = EBADF;
 			return -1;
@@ -557,7 +557,7 @@ public:
 	}
 	off_t lseek(int fd, off_t offset, int whence) {
 		ASSERT(fd > 0);
-		auto& f = fds[fd];
+		auto& f = fds.at(fd);
 		if (whence == SEEK_SET) {
 			f.offset = offset;
 		} else if (whence == SEEK_END) {


### PR DESCRIPTION
`[]` requires default constructor. `at()` is better here to throw exception when fd is not existed.

# Code-Reviewer Section

The general guidelines can be found [here](https://github.com/apple/foundationdb/wiki/FoundationDB-Commit-Process).

Please check each of the following things and check *all* boxes before accepting a PR.

- [ ] The PR has a description, explaining both the problem and the solution.
- [ ] The description mentions which forms of testing were done and the testing seems reasonable.
- [ ] Every function/class/actor that was touched is reasonably well documented.

## For Release-Branches

If this PR is made against a release-branch, please also check the following:

- [ ] This change/bugfix is a cherry-pick from the next younger branch (younger `release-branch` or `master` if this is the youngest branch)
- [ ] There is a good reason why this PR needs to go into a release branch and this reason is documented (either in the description above or in a linked GitHub issue)
