### PR TITLE
Utilities for making trace logs work with the fuzzer

### DIFF
--- a/flow/FileTraceLogWriter.h
+++ b/flow/FileTraceLogWriter.h
@@ -61,9 +61,6 @@ private:
 
 	std::function<void()> onError;
 
-	// needs to be a reference since setter not defined by ITraceLogWriter
-	bool& closeOnExec;
-
 	void write(const char* str, size_t size);
 
 public:
@@ -74,8 +71,7 @@ public:
 	                   std::string const& tracePartialFileSuffix,
 	                   uint64_t maxLogsSize,
 	                   std::function<void()> const& onError,
-	                   Reference<ITraceLogIssuesReporter> const& issues,
-	                   bool& closeOnExec);
+	                   Reference<ITraceLogIssuesReporter> const& issues);
 
 	void addref() override;
 	void delref() override;

--- a/flow/FileTraceLogWriter.h
+++ b/flow/FileTraceLogWriter.h
@@ -61,6 +61,9 @@ private:
 
 	std::function<void()> onError;
 
+	// needs to be a reference since setter not defined by ITraceLogWriter
+	bool& closeOnExec;
+
 	void write(const char* str, size_t size);
 
 public:
@@ -71,7 +74,8 @@ public:
 	                   std::string const& tracePartialFileSuffix,
 	                   uint64_t maxLogsSize,
 	                   std::function<void()> const& onError,
-	                   Reference<ITraceLogIssuesReporter> const& issues);
+	                   Reference<ITraceLogIssuesReporter> const& issues,
+	                   bool& closeOnExec);
 
 	void addref() override;
 	void delref() override;

--- a/flow/Trace.cpp
+++ b/flow/Trace.cpp
@@ -570,7 +570,7 @@ public:
 		// since FileTraceLogWriter has a reference to this->closeOnExec, this change will get propogated to the writer
 		numChildProcesses++;
 		closeOnExec = false;
-		logGroup = childLogGroup;
+		logGroup = childLogGroup; // TODO: use a stack to support depth > 1 eventually
 	}
 
 	void terminateChildProcess() {

--- a/flow/Trace.cpp
+++ b/flow/Trace.cpp
@@ -808,6 +808,10 @@ void removeTraceRole(std::string const& role) {
 	g_traceLog.removeRole(role);
 }
 
+std::string getTraceLogGroup() {
+	return g_traceLog.getLogGroup();
+}
+
 void setTraceLogGroup(const std::string& logGroup) {
 	g_traceLog.setLogGroup(logGroup);
 }

--- a/flow/Trace.h
+++ b/flow/Trace.h
@@ -586,6 +586,7 @@ bool validateTraceClockSource(std::string source);
 void addTraceRole(std::string const& role);
 void removeTraceRole(std::string const& role);
 void retrieveTraceLogIssues(std::set<std::string>& out);
+std::string getTraceLogGroup();
 void setTraceLogGroup(const std::string& role);
 void startChildTraceLog(const std::string& childLogGroup);
 void terminateChildTraceLog();

--- a/flow/Trace.h
+++ b/flow/Trace.h
@@ -587,6 +587,10 @@ void addTraceRole(std::string const& role);
 void removeTraceRole(std::string const& role);
 void retrieveTraceLogIssues(std::set<std::string>& out);
 void setTraceLogGroup(const std::string& role);
+void startChildTraceLog(const std::string& childLogGroup);
+void terminateChildTraceLog();
+void setCloseOnExec(bool closeOnExec);
+
 template <class T>
 class Future;
 class Void;

--- a/flow/Trace.h
+++ b/flow/Trace.h
@@ -589,7 +589,6 @@ void retrieveTraceLogIssues(std::set<std::string>& out);
 void setTraceLogGroup(const std::string& role);
 void startChildTraceLog(const std::string& childLogGroup);
 void terminateChildTraceLog();
-void setCloseOnExec(bool closeOnExec);
 
 template <class T>
 class Future;


### PR DESCRIPTION
This PR:
- disables rolling of trace files when the fuzzer is being used
- disables close-on-exec for trace files when the fuzzer is being used
- exposes utilities such as setup and teardown of child processes (in terms of trace files)

# Code-Reviewer Section

The general guidelines can be found [here](https://github.com/apple/foundationdb/wiki/FoundationDB-Commit-Process).

Please check each of the following things and check *all* boxes before accepting a PR.

- [ ] The PR has a description, explaining both the problem and the solution.
- [ ] The description mentions which forms of testing were done and the testing seems reasonable.
- [ ] Every function/class/actor that was touched is reasonably well documented.

## For Release-Branches

If this PR is made against a release-branch, please also check the following:

- [ ] This change/bugfix is a cherry-pick from the next younger branch (younger `release-branch` or `master` if this is the youngest branch)
- [ ] There is a good reason why this PR needs to go into a release branch and this reason is documented (either in the description above or in a linked GitHub issue)
