### PR TITLE
fix child process return bug

### DIFF
--- a/fdbrpc/sim2.actor.cpp
+++ b/fdbrpc/sim2.actor.cpp
@@ -2333,6 +2333,7 @@ public:
 				    .detail("NewSeed", new_seed)
 				    .detail("ProcessId", pid)
 				    .detail("Context", context);
+				return 0;
 			} else if (processId < 0) {
 				return EXIT_FAILURE;
 			} else { // parent process


### PR DESCRIPTION
child process should return from the iteration to continue run
# Code-Reviewer Section

The general guidelines can be found [here](https://github.com/apple/foundationdb/wiki/FoundationDB-Commit-Process).

Please check each of the following things and check *all* boxes before accepting a PR.

- [ ] The PR has a description, explaining both the problem and the solution.
- [ ] The description mentions which forms of testing were done and the testing seems reasonable.
- [ ] Every function/class/actor that was touched is reasonably well documented.

## For Release-Branches

If this PR is made against a release-branch, please also check the following:

- [ ] This change/bugfix is a cherry-pick from the next younger branch (younger `release-branch` or `master` if this is the youngest branch)
- [ ] There is a good reason why this PR needs to go into a release branch and this reason is documented (either in the description above or in a linked GitHub issue)
